### PR TITLE
sink: revamp API to provide easier usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [crate]: https://crates.io/crates/hotmic
 [docs]: https://docs.rs/hotmic
 
-__hotmic__ is a high-speed metrics collection library, based on [crossbeam-channel](https://github.com/crossbeam-rs/crossbeam-channel).  It is shameless fork of [tic](https://github.com/brayniac/tic) with some internal changes to support `crossbeam-channel` and to fit my needs better.  This project would not be possible without `tic`!
+__hotmic__ is a high-speed metrics collection library, based on [crossbeam-channel](https://github.com/crossbeam-rs/crossbeam-channel).  It is heavily inspired by [tic](https://github.com/brayniac/tic).
 
 ## code of conduct
 
@@ -38,20 +38,9 @@ The API documentation of this library can be found at [docs.rs/hotmic](https://d
 
 This section used to have way higher numbers, and a full comparison vs `tic`, but based on recent refactoring, the numbers are off.  Here's a quick look at the current performance of `hotmic`:
 
-    # RUST_LOG=debug target/release/examples/benchmark --duration 30 --producers 1 --capacity 128
-    [2018-12-23T01:55:55Z INFO  benchmark] latency (ns): p50: 387 p90: 433 p99: 494 p999: 697 max: 838655
-    [2018-12-23T01:55:56Z INFO  benchmark] total metrics pushed: 147845436
+    # RUST_LOG=debug target/release/examples/benchmark --duration 30 --producers 1 --capacity 4096
+    [2019-01-20T00:49:06Z INFO  benchmark] rate: 4991107.330041891 samples per second
+    [2019-01-20T00:49:06Z INFO  benchmark] latency (ns): p50: 389 p90: 422 p99: 520 p999: 783 max: 2077695
+    [2019-01-20T00:49:07Z INFO  benchmark] total metrics pushed: 296547696
 
 The latency values are measured from the perspective of the thread sending into the metric sink.  This section will contain better data -- including visual aids! -- in the near future.
-
-(hotmic fcc9f5c26e77a6493b83b224ba189f1824ae1a53, December 2018)
-
-## wall of recognition
-
-Again, this project is a fork of `tic`, and I want to personally thank @brayniac for creating `tic` and for being a gracious open source contributor and steward.  He has many crates you should check out -- many centered around high-performance metrics -- and I can personally attest to his graciousness in issues/PRs.
-
-## license
-
-Per the flexible `tic` licensing terms, __hotmic__ is released solely under the MIT license. ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
-
-Attribution information for `tic` can be found in the same license file.

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -5,7 +5,7 @@ extern crate getopts;
 extern crate hotmic;
 
 use getopts::Options;
-use hotmic::{Facet, Percentile, Receiver, Sample, Sink};
+use hotmic::{Facet, Percentile, Receiver, Sink};
 use std::{
     env, fmt, thread,
     time::{Duration, Instant},
@@ -47,8 +47,8 @@ impl Generator {
             let t1 = self.stats.clock().raw();
 
             if let Some(t0) = self.t0 {
-                let _ = self.stats.send(Sample::Timing(Metric::Ok, t0, t1, 1));
-                let _ = self.stats.send(Sample::Value(Metric::Total, self.gauge));
+                let _ = self.stats.update_timing(Metric::Ok, t0, t1);
+                let _ = self.stats.update_value(Metric::Total, self.gauge);
             }
             self.t0 = Some(t1);
         }
@@ -116,7 +116,7 @@ fn main() {
     let mut receiver = Receiver::builder().capacity(capacity).build();
 
     let sink = receiver.get_sink();
-    let mut sink = sink.scoped("alpha.pools.primary").expect("failed to create sink");
+    let sink = sink.scoped("alpha.pools.primary").expect("failed to create sink");
     sink.add_facet(Facet::Count(Metric::Ok));
     sink.add_facet(Facet::TimingPercentile(Metric::Ok));
     sink.add_facet(Facet::Count(Metric::Total));

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,7 +1,7 @@
 use super::receiver::Receiver;
 use std::{fmt::Display, hash::Hash, marker::PhantomData};
 
-/// A configuration builder for `Receiver`.
+/// A configuration builder for [`Receiver`].
 #[derive(Clone)]
 pub struct Configuration<T> {
     metric_type: PhantomData<T>,
@@ -18,7 +18,7 @@ impl<T> Default for Configuration<T> {
 }
 
 impl<T: Send + Eq + Hash + Display + Clone> Configuration<T> {
-    /// Creates a new `Configuration` with default values.
+    /// Creates a new [`Configuration`] with default values.
     pub fn new() -> Configuration<T> { Default::default() }
 
     /// Sets the buffer capacity.
@@ -40,6 +40,6 @@ impl<T: Send + Eq + Hash + Display + Clone> Configuration<T> {
         self
     }
 
-    /// Create a `Receiver` based on this configuration.
+    /// Create a [`Receiver`] based on this configuration.
     pub fn build(self) -> Receiver<T> { Receiver::from_config(self) }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,31 +1,30 @@
-use super::{
-    data::{Facet, ScopedKey, Snapshot},
-    helper::io_error,
-};
+use super::{data::Snapshot, helper::io_error};
 use crossbeam_channel::{bounded, Sender};
-use std::{fmt::Display, hash::Hash, io};
+use std::io;
 
-pub(crate) enum ControlMessage<T> {
-    AddFacet(Facet<T>),
-    RemoveFacet(Facet<T>),
+/// Various control actions performed by a controller.
+pub(crate) enum ControlFrame {
+    /// Takes a snapshot of the current metric state.
+    ///
+    /// Caller must supply a [`Sender`] instance which the result can be sent to.
     Snapshot(Sender<Snapshot>),
 }
 
-/// Dedicated handle for performing operations on a running `Receiver`.
+/// Dedicated handle for performing operations on a running [`Receiver`](crate::receiver::Receiver).
 ///
 /// The caller is able to request metric snapshots at any time without requiring mutable access to
 /// the sink.  This all flows through the existing control mechanism, and so is very fast.
-pub struct Controller<T: Clone + Eq + Hash + Display> {
-    control_tx: Sender<ControlMessage<ScopedKey<T>>>,
+pub struct Controller {
+    control_tx: Sender<ControlFrame>,
 }
 
-impl<T: Clone + Eq + Hash + Display> Controller<T> {
-    pub(crate) fn new(control_tx: Sender<ControlMessage<ScopedKey<T>>>) -> Controller<T> { Controller { control_tx } }
+impl Controller {
+    pub(crate) fn new(control_tx: Sender<ControlFrame>) -> Controller { Controller { control_tx } }
 
     /// Retrieves a snapshot of the current metric state.
     pub fn get_snapshot(&self) -> Result<Snapshot, io::Error> {
         let (tx, rx) = bounded(0);
-        let msg = ControlMessage::Snapshot(tx);
+        let msg = ControlFrame::Snapshot(tx);
 
         match self.control_tx.send(msg) {
             Ok(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,172 @@
+//! High-speed metrics collection library.
+//!
+//! hotmic provides a generalized metrics collection library targeted at users who want to log
+//! metrics at high volume and high speed.
+//!
+//! # Design
+//!
+//! The library follows a pattern of "senders" and a "receiver."
+//!
+//! Callers create a [`Receiver`], which acts as a contained unit: metric registration,
+//! aggregation, and summarization.  The [`Receiver`] is intended to be spawned onto a dedicated
+//! background thread.
+//!
+//! From a [`Receiver`], callers can create a [`Sink`], which allows registering facets -- or
+//! interests -- in a given metric, along with sending the metrics themselves.  All metrics need to
+//! be pre-registered, in essence, with the receiver, which allows us to know which aspects of a
+//! metric to track: count, value, or percentile.
+//!
+//! A [`Sink`] can be cheaply cloned and does not require a mutable reference to send metrics, and
+//! so callers have great flexibility in being able to control their resource consumption when it
+//! comes to sinks. [`Receiver`] also allows configuring the capacity of the underlying channels to
+//! finely tune resource consumption.
+//!
+//! Being based on [`crossbeam-channel`] allows us to process close to five million metrics per second
+//! on a single core, with very low ingest latencies: 325-350ns on average at full throughput.
+//!
+//! # Metrics
+//!
+//! hotmic supports counters, gauges, and histograms.
+//!
+//! A counter is a single value that can be updated with deltas to increase or decrease the value.
+//! This would be your typical "messages sent" or "database queries executed" style of metric,
+//! where the value changes over time.
+//!
+//! A gauge is also a single value but does not support delta updates.  When a gauge is set, the
+//! value sent becomes _the_ value of the gauge.  Gauges can be useful for metrics that measure a
+//! point-in-time value, such as "connected clients" or "running queries".  While those metrics
+//! could also be represented by a count, gauges can be simpler in cases where you're already
+//! computing and storing the value, and simply want to expose it in your metrics.
+//!
+//! A histogram tracks the distribution of values: how many values were between 0-5, between 6-10,
+//! etc.  This is the canonical way to measure latency: the time spent running a piece of code or
+//! servicing an operation.  By keeping track of the individual measurements, we can better see how
+//! many are slow, fast, average, and in what proportions.
+//!
+//! ```
+//! # extern crate hotmic;
+//! use hotmic::{Facet, Receiver};
+//! use std::thread;
+//! let receiver = Receiver::builder().build();
+//! let sink = receiver.get_sink();
+//!
+//! // We have to register the metrics we care about so that they're properly tracked!
+//! sink.add_facet(Facet::Count("widget"));
+//! sink.add_facet(Facet::Gauge("red_balloons"));
+//! sink.add_facet(Facet::TimingPercentile("db.gizmo_query"));
+//! sink.add_facet(Facet::Count("db.gizmo_query"));
+//! sink.add_facet(Facet::ValuePercentile("buf_size"));
+//!
+//! // We can send a simple count, which is a signed value, so the value we give is applied as a
+//! // delta to the underlying counter.  After these sends, "widgets" would be 3.
+//! assert!(sink.update_count("widgets", 5).is_ok());
+//! assert!(sink.update_count("widgets", -3).is_ok());
+//! assert!(sink.update_count("widgets", 1).is_ok());
+//!
+//! // We can update a gauge.  This is just a point-in-time value so the last "write" of this
+//! // metric is what the value will be, and it will stay at that value until changed.
+//! assert!(sink.update_value("red_balloons", 99).is_ok());
+//!
+//! // We can update a timing percentile.  For timing, you also must measure the start and end
+//! // time using the built-in `Clock` exposed by the sink.  The receiver internally converts the
+//! // raw values to calculate the actual wall clock time (in nanoseconds) on your behalf, so you
+//! // can't just pass in any old number.. otherwise you'll get erroneous measurements!
+//! let start = sink.clock().start();
+//! thread::sleep_ms(10);
+//! let end = sink.clock().end();
+//! let rows = 42;
+//!
+//! // This would just set the timing:
+//! assert!(sink.update_timing("db.gizmo_query", start, end).is_ok());
+//!
+//! // This would set the timing and also let you provide a customized count value.  Being able to
+//! // specify a count is handy when tracking things like the time it took to execute a database
+//! // query, along with how many rows that query returned:
+//! assert!(sink
+//!     .update_timing_with_count("db.gizmo_query", start, end, rows)
+//!     .is_ok());
+//!
+//! // Finally, we can update a value percentile.  Technically speaking, value percentiles aren't
+//! // fundamentally different from timing percentiles.  If you use a timing percentile, we do the
+//! // math for you of getting the time difference, and we make sure the metric name has the right
+//! // unit suffix so you can tell it's measuring time, but other than that, nearly identical!
+//! let buf_size = 4096;
+//! assert!(sink.update_value("buf_size", buf_size).is_ok());
+//! ```
+//!
+//! # Facets
+//!
+//! Facets are the way callers specify what they're interested in.  Without any other
+//! configuration, you could send any metric you want but nothing would happen; nothing would be
+//! recorded.
+//!
+//! Facets correspond roughly to the metric types, with the exception of the difference between
+//! timing percentiles and value percentiles, which both are histogram-based but differ in how we
+//! render their metric labels.
+//!
+//! Thus, if you want to record a counter, you would register a counter facet for the given metric
+//! key, and if you want to track latency for a given operation, you would register a timing
+//! percentile for the metric key used.
+//!
+//! Facets and scoping (explained below) are intrinsically tied together, so facets need to be
+//! registered directly on the sink they'll be used from in order to ensure that the facet matches
+//! the scope of the sink:
+//!
+//! ```
+//! # extern crate hotmic;
+//! use hotmic::{Facet, Receiver};
+//! let receiver = Receiver::builder().build();
+//!
+//! // This sink has no scope aka the root scope.  We can register facets on this sink without a
+//! // problem, but if get a scoped sink from this one, and sent the same metric name, the scopes
+//! // would not line up, and the metric wouldn't be registered for storage.
+//! let root_sink = receiver.get_sink();
+//! root_sink.add_facet(Facet::Count("widgets"));
+//! assert!(root_sink.update_count("widgets", 42).is_ok());
+//!
+//! // Make a new scoped sink.  If we tried to send to this new sink, without reregistering our
+//! // facets, our metrics wouldn't be stored at all.
+//! let scoped_sink = root_sink.scoped("party").unwrap();
+//!
+//! // Register the facet, and we're all good.
+//! scoped_sink.add_facet(Facet::Count("widgets"));
+//! assert!(scoped_sink.update_count("widgets", 43).is_ok());
+//! ```
+//!
+//! # Scopes
+//!
+//! Metrics can be scoped, not unlike loggers, at the [`Sink`] level.  This allows sinks to easily
+//! nest themselves without callers ever needing to care about where they're located.
+//!
+//! This feature is a simpler approach to tagging: while not as semantically rich, it provides the
+//! level of detail necessary to distinguish a single metric between multiple callsites.
+//!
+//! For example, after getting a [`Sink`] from the [`Receiver`], we can easily nest ourselves under
+//! the root scope and then send some metrics:
+//!
+//! ```
+//! # extern crate hotmic;
+//! use hotmic::Receiver;
+//! let receiver = Receiver::builder().build();
+//!
+//! // This sink has no scope aka the root scope.  The metric will just end up as "widgets".
+//! let root_sink = receiver.get_sink();
+//! assert!(root_sink.update_count("widgets", 42).is_ok());
+//!
+//! // This sink is under the "secret" scope.  Since we derived ourselves from the root scope,
+//! // we're not nested under anything, but our metric name will end up being "secret.widgets".
+//! let scoped_sink = root_sink.scoped("secret").unwrap();
+//! assert!(scoped_sink.update_count("widgets", 42).is_ok());
+//!
+//! // This sink is under the "supersecret" scope, but we're also nested!  The metric name for this
+//! // sample will end up being "secret.supersecret.widget".
+//! let scoped_sink_two = scoped_sink.scoped("supersecret").unwrap();
+//! assert!(scoped_sink_two.update_count("widgets", 42).is_ok());
+//!
+//! // Sinks retain their scope even when cloned, so the metric name will be the same as above.
+//! let cloned_sink = scoped_sink_two.clone();
+//! assert!(cloned_sink.update_count("widgets", 42).is_ok());
+//! ```
 mod configuration;
 mod control;
 mod data;
@@ -8,7 +177,7 @@ mod sink;
 pub use self::{
     configuration::Configuration,
     control::Controller,
-    data::{Facet, Percentile, Sample, Snapshot},
+    data::{Facet, Percentile, Snapshot},
     receiver::Receiver,
     sink::{Sink, SinkError},
 };

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,8 +1,7 @@
 use crate::{
-    control::ControlMessage,
-    data::{DataFrame, Facet, Sample, ScopedKey},
+    data::{Facet, Sample, ScopedKey},
     helper::io_error,
-    receiver::get_scope_id,
+    receiver::{get_scope_id, MessageFrame, UpkeepMessage},
 };
 use crossbeam_channel::Sender;
 use quanta::Clock;
@@ -17,11 +16,10 @@ pub enum SinkError {
 
 /// Handle for sending metric samples into the receiver.
 ///
-/// `Sink` is cloneable, and can not only send metric samples but can register and deregister
+/// [`Sink`] is cloneable, and can not only send metric samples but can register and deregister
 /// metric facets at any time.
 pub struct Sink<T: Clone + Eq + Hash + Display> {
-    data_tx: Sender<DataFrame<ScopedKey<T>>>,
-    control_tx: Sender<ControlMessage<ScopedKey<T>>>,
+    msg_tx: Sender<MessageFrame<ScopedKey<T>>>,
     clock: Clock,
     scope: String,
     scope_id: usize,
@@ -29,8 +27,7 @@ pub struct Sink<T: Clone + Eq + Hash + Display> {
 
 impl<T: Clone + Eq + Hash + Display> Sink<T> {
     pub(crate) fn new(
-        data_tx: Sender<DataFrame<ScopedKey<T>>>, control_tx: Sender<ControlMessage<ScopedKey<T>>>, clock: Clock,
-        scope: String, scope_id: usize,
+        msg_tx: Sender<MessageFrame<ScopedKey<T>>>, clock: Clock, scope: String, scope_id: usize,
     ) -> Sink<T> {
         // Register our scope with the receiver.  We send this over the data channel because the
         // control channel is usually smaller, so we have a better chance of not deadlocking
@@ -40,38 +37,37 @@ impl<T: Clone + Eq + Hash + Display> Sink<T> {
         //
         // Long story short, we need to make sure we register the scope before processing any data
         // samples, so we shove them both into the same channel to get that guarantee.
-        let _ = data_tx.send(DataFrame::Scope(scope_id, scope.clone()));
+        let umsg = UpkeepMessage::RegisterScope(scope_id, scope.clone());
+        let _ = msg_tx.send(MessageFrame::Upkeep(umsg));
 
         Sink {
-            data_tx,
-            control_tx,
+            msg_tx,
             clock,
             scope,
             scope_id,
         }
     }
 
-    /// Creates a scoped clone of this `Sink`.
+    /// Creates a scoped clone of this [`Sink`].
     ///
-    /// Scoping controls the resulting metric name for any metrics sent by this `Sink`.  For
-    /// example, with an imaginary `MetricType::MessagesSent`, you may normally display that
-    /// as `messages_sent`.
+    /// Scoping controls the resulting metric name for any metrics sent by this [`Sink`].  For
+    /// example, you might have a metric called `messages_sent`.
     ///
     /// With scoping, you could have independent versions of the same metric.  This is useful for
     /// having the same "base" metric name but with broken down values.
     ///
     /// Going further with the above example, if you had a server, and listened on multiple
-    /// addresses, maybe you would have a scoped `Sink` per listener, and could end up with metrics
-    /// that look like this:
+    /// addresses, maybe you would have a scoped [`Sink`] per listener, and could end up with
+    /// metrics that look like this:
     /// - `listener.a.messages_sent`
     /// - `listener.b.messages_sent`
     /// - `listener.c.messages_sent`
     /// - etc
     ///
-    /// Scopes are also inherited.  If you create a scoped `Sink` from another `Sink` which is
+    /// Scopes are also inherited.  If you create a scoped [`Sink`] from another [`Sink`] which is
     /// already scoped, the scopes will be merged together using a `.` as the string separator.
-    /// This makes it easy to nest scopes.  These scopes are fully contained, though, and so a
-    /// scoped child `Sink` does not depend on its parent to exist.
+    /// This makes it easy to nest scopes.  Cloning a scoped [`Sink`], though, will inherit the
+    /// same scope as the original.
     pub fn scoped(&self, scope: &str) -> Result<Sink<T>, SinkError> {
         if scope.is_empty() {
             return Err(SinkError::InvalidScope);
@@ -84,8 +80,7 @@ impl<T: Clone + Eq + Hash + Display> Sink<T> {
         new_scope.push_str(scope);
 
         Ok(Sink::new(
-            self.data_tx.clone(),
-            self.control_tx.clone(),
+            self.msg_tx.clone(),
             self.clock.clone(),
             new_scope,
             get_scope_id(),
@@ -95,31 +90,52 @@ impl<T: Clone + Eq + Hash + Display> Sink<T> {
     /// Reference to the internal high-speed clock interface.
     pub fn clock(&self) -> &Clock { &self.clock }
 
-    /// Sends a metric sample to the receiver.
-    pub fn send(&mut self, sample: Sample<T>) -> Result<(), io::Error> {
-        self.data_tx
-            .send(DataFrame::Sample(sample.into_scoped(self.scope_id)))
+    /// Updates the count for a given metric.
+    pub fn update_count(&self, key: T, delta: i64) -> Result<(), io::Error> { self.send(Sample::Count(key, delta)) }
+
+    /// Updates the value for a given metric.
+    ///
+    /// This can be used either for setting a gauge or updating a value percentile.
+    pub fn update_value(&self, key: T, value: u64) -> Result<(), io::Error> { self.send(Sample::Value(key, value)) }
+
+    /// Updates the timing for a given metric.
+    pub fn update_timing(&self, key: T, start: u64, end: u64) -> Result<(), io::Error> {
+        self.send(Sample::Timing(key, start, end, 1))
+    }
+
+    /// Updates the timing for a given metric, with a count.
+    pub fn update_timing_with_count(&self, key: T, start: u64, end: u64, count: u64) -> Result<(), io::Error> {
+        self.send(Sample::Timing(key, start, end, count))
+    }
+
+    /// Sends a raw metric sample to the receiver.
+    fn send(&self, sample: Sample<T>) -> Result<(), io::Error> {
+        self.msg_tx
+            .send(MessageFrame::Data(sample.into_scoped(self.scope_id)))
             .map_err(|_| io_error("failed to send sample"))
     }
 
     /// Registers a facet with the receiver.
-    pub fn add_facet(&mut self, facet: Facet<T>) {
+    pub fn add_facet(&self, facet: Facet<T>) {
         let scoped_facet = facet.into_scoped(self.scope_id);
-        let _ = self.control_tx.send(ControlMessage::AddFacet(scoped_facet));
+        let _ = self
+            .msg_tx
+            .send(MessageFrame::Upkeep(UpkeepMessage::AddFacet(scoped_facet)));
     }
 
     /// Deregisters a facet from the receiver.
-    pub fn remove_facet(&mut self, facet: Facet<T>) {
+    pub fn remove_facet(&self, facet: Facet<T>) {
         let scoped_facet = facet.into_scoped(self.scope_id);
-        let _ = self.control_tx.send(ControlMessage::RemoveFacet(scoped_facet));
+        let _ = self
+            .msg_tx
+            .send(MessageFrame::Upkeep(UpkeepMessage::RemoveFacet(scoped_facet)));
     }
 }
 
 impl<T: Clone + Eq + Hash + Display> Clone for Sink<T> {
     fn clone(&self) -> Sink<T> {
         Sink {
-            data_tx: self.data_tx.clone(),
-            control_tx: self.control_tx.clone(),
+            msg_tx: self.msg_tx.clone(),
             clock: self.clock.clone(),
             scope: self.scope.clone(),
             scope_id: self.scope_id,


### PR DESCRIPTION
This commit adds helper methods to `Sink` to make it easier to send metrics, rather than forcing users to have to construct the `Sample` entry themselves.  It covers all cases and so we've also removed the `send` method, which means we can also hide away `Sample`, which being an enum, was also annoying to document cleanly because of all the positional arguments.

We've also revved up the documentation a bit, including adding examples to the library-level documentation.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>