### PR TITLE
Fixed a bug with identical scopes overwriting each others metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Changed
-- Fixed a bug where new sinks with the same scope would overwrite each others metrics.
+- Fixed a bug where new sinks with the same scope would overwrite each others metrics. [#20](https://github.com/nuclearfurnace/hotmic/pull/20)
 
 ## [0.7.0] - 2019-01-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Fixed a bug where new sinks with the same scope would overwrite each others metrics.
 
 ## [0.7.0] - 2019-01-27
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ lto = true
 
 [dependencies]
 crossbeam-channel = "^0.3"
+parking_lot = "^0.7"
 hdrhistogram = "^6.1"
 fnv = "^1.0"
 hashbrown = "^0.1"

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -137,13 +137,10 @@ fn main() {
     info!("capacity: {}", capacity);
     info!("batch size: {}", batch_size);
 
-    let mut receiver = Receiver::builder()
-        .capacity(capacity)
-        .batch_size(batch_size)
-        .build();
+    let mut receiver = Receiver::builder().capacity(capacity).batch_size(batch_size).build();
 
     let sink = receiver.get_sink();
-    let sink = sink.scoped(&["alpha","pools","primary"]);
+    let sink = sink.scoped(&["alpha", "pools", "primary"]);
 
     info!("sink configured");
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -52,10 +52,10 @@ pub(crate) enum Sample<T> {
 
 /// An integer scoped metric key.
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
-pub(crate) struct ScopedKey<T: Clone + Eq + Hash + Display>(usize, T);
+pub(crate) struct ScopedKey<T: Clone + Eq + Hash + Display>(u64, T);
 
 impl<T: Clone + Eq + Hash + Display> ScopedKey<T> {
-    pub(crate) fn id(&self) -> usize { self.0 }
+    pub(crate) fn id(&self) -> u64 { self.0 }
 
     pub(crate) fn into_string_scoped(self, scope: String) -> StringScopedKey<T> { StringScopedKey(scope, self.1) }
 }
@@ -75,7 +75,7 @@ impl<T: Clone + Hash + Eq + Display> Display for StringScopedKey<T> {
 }
 
 impl<T: Clone + Eq + Hash + Display> Sample<T> {
-    pub(crate) fn into_scoped(self, scope_id: usize) -> Sample<ScopedKey<T>> {
+    pub(crate) fn into_scoped(self, scope_id: u64) -> Sample<ScopedKey<T>> {
         match self {
             Sample::Count(key, value) => Sample::Count(ScopedKey(scope_id, key), value),
             Sample::Gauge(key, value) => Sample::Gauge(ScopedKey(scope_id, key), value),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ mod control;
 mod data;
 mod helper;
 mod receiver;
+mod scopes;
 mod sink;
 
 pub use self::{

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -1,0 +1,53 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+
+pub struct Inner {
+    id: u64,
+    forward: HashMap<String, u64>,
+    backward: HashMap<u64, String>,
+}
+
+impl Inner {
+    pub fn new() -> Self {
+        Inner {
+            id: 1,
+            forward: HashMap::new(),
+            backward: HashMap::new(),
+        }
+    }
+}
+
+pub struct Scopes {
+    inner: RwLock<Inner>,
+}
+
+impl Scopes {
+    pub fn new() -> Self {
+        Scopes {
+            inner: RwLock::new(Inner::new()),
+        }
+    }
+
+    pub fn register(&self, scope: String) -> u64 {
+        let mut wg = self.inner.write();
+
+        // If the key is already registered, send back the existing scope ID.
+        if wg.forward.contains_key(&scope) {
+            return wg.forward.get(&scope).cloned().unwrap();
+        }
+
+        // Otherwise, take the current scope ID for this registration, store it, and increment
+        // the scope ID counter for the next registration.
+        let scope_id = wg.id;
+        let _ = wg.forward.insert(scope.clone(), scope_id);
+        let _ = wg.backward.insert(scope_id, scope);
+        wg.id += 1;
+        scope_id
+    }
+
+    pub fn get(&self, scope_id: u64) -> Option<String> {
+        // See if we have an entry for the scope ID, and clone the scope if so.
+        let rg = self.inner.read();
+        rg.backward.get(&scope_id).cloned()
+    }
+}


### PR DESCRIPTION
Due to the way scopes were allocating their scope IDs, duplicate scopes would be storing metrics under different scope IDs but end up being overwritten when a snapshot was generated: the latest version of a scope would have their metric as the "winner".

We've now changed this so that sinks register their scope directly instead of sending a unary message to the receiver.  This means a few things:
- sinks get told what their scope ID is, so we can deduplicate
- we go through a RW locked mechanism (slower, but still fast)
- we have the potential to clean up scope entries when the sink drops

Synchronizing the creation of a sink on a RW lock isn't great, but in practice, unless you're creating a lot of sinks all the same, like probably thousands per second? then this approach should be OK.  I will add a bench test at some point for the uncontested overhead but I'm not super worried about it.

Dropping stale scope entries is a future optimization to help with
memory consumption but scope memory usage is likely dwarfed by a few
orders of magnitude if a user has any histograms, etc.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>