### PR TITLE
Revamp snapshotting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed accessors from `Snapshot`.  It is not an opaque type that can be turned into an iterator which will provide access to typed metric values so that an external consumer can get all of the values in the snapshot, including their type, for proper exporting.
+### Added
+- A new "simple" snapshot type -- `SimpleSnapshot` -- which has easy-to-use accessors for metrics, identical to what `Snapshot` used to have.
+- Allow retrieving snapshots asynchronously via `Controller::get_snapshot_async`.  Utilizes a oneshot channel so the caller can poll asynchronously.
 
 ## [0.7.1] - 2019-01-28
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ fnv = "^1.0"
 hashbrown = "^0.1"
 quanta = "^0.2"
 serde = "^1.0"
+derivative = "^1.0"
 tokio-sync = "^0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ fnv = "^1.0"
 hashbrown = "^0.1"
 quanta = "^0.2"
 serde = "^1.0"
+tokio-sync = "^0.1"
 
 [dev-dependencies]
 log = "^0.4"

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -101,7 +101,7 @@ fn main() {
         Err(f) => {
             error!("Failed to parse command line args: {}", f);
             return;
-        },
+        }
     };
 
     if matches.opt_present("help") {
@@ -178,16 +178,17 @@ fn main() {
         let mut turn_total = 0;
 
         let start = Instant::now();
-        let snapshot = controller.get_snapshot().unwrap();
+        let snapshot = controller.get_snapshot();
         let end = Instant::now();
         snapshot_hist.saturating_record(duration_as_nanos(end - start) as u64);
 
+        let snapshot = snapshot.unwrap().into_simple();
         if let Some(t) = snapshot.count(&ok_key) {
-            turn_total += *t as u64;
+            turn_total += t as u64;
         }
 
         if let Some(t) = snapshot.gauge(&total_key) {
-            turn_total += *t;
+            turn_total += t;
         }
 
         let turn_delta = turn_total - total;
@@ -218,7 +219,9 @@ fn main() {
     }
 }
 
-fn duration_as_nanos(d: Duration) -> f64 { (d.as_secs() as f64 * 1e9) + d.subsec_nanos() as f64 }
+fn duration_as_nanos(d: Duration) -> f64 {
+    (d.as_secs() as f64 * 1e9) + d.subsec_nanos() as f64
+}
 
 fn nanos_to_readable(t: u64) -> String {
     let f = t as f64;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -27,7 +27,9 @@ impl<T> Default for Configuration<T> {
 
 impl<T: Send + Eq + Hash + Display + Clone> Configuration<T> {
     /// Creates a new [`Configuration`] with default values.
-    pub fn new() -> Configuration<T> { Default::default() }
+    pub fn new() -> Configuration<T> {
+        Default::default()
+    }
 
     /// Sets the buffer capacity.
     ///
@@ -97,7 +99,9 @@ impl<T: Send + Eq + Hash + Display + Clone> Configuration<T> {
     }
 
     /// Create a [`Receiver`] based on this configuration.
-    pub fn build(self) -> Receiver<T> { Receiver::from_config(self) }
+    pub fn build(self) -> Receiver<T> {
+        Receiver::from_config(self)
+    }
 }
 
 /// A default set of percentiles that should support most use cases.

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,13 +1,16 @@
-use super::{data::Snapshot, helper::io_error};
+use super::{
+    data::{Snapshot, SnapshotError},
+};
 use crossbeam_channel::{bounded, Sender};
-use std::io;
+use tokio_sync::oneshot;
 
 /// Various control actions performed by a controller.
 pub(crate) enum ControlFrame {
     /// Takes a snapshot of the current metric state.
-    ///
-    /// Caller must supply a [`Sender`] instance which the result can be sent to.
     Snapshot(Sender<Snapshot>),
+
+    /// Takes a snapshot of the current metric state, but uses an asynchronous channel.
+    SnapshotAsync(oneshot::Sender<Snapshot>),
 }
 
 /// Dedicated handle for performing operations on a running [`Receiver`](crate::receiver::Receiver).
@@ -23,18 +26,22 @@ impl Controller {
     pub(crate) fn new(control_tx: Sender<ControlFrame>) -> Controller { Controller { control_tx } }
 
     /// Retrieves a snapshot of the current metric state.
-    pub fn get_snapshot(&self) -> Result<Snapshot, io::Error> {
+    pub fn get_snapshot(&self) -> Result<Snapshot, SnapshotError> {
         let (tx, rx) = bounded(0);
         let msg = ControlFrame::Snapshot(tx);
 
-        match self.control_tx.send(msg) {
-            Ok(_) => {
-                match rx.recv() {
-                    Ok(result) => Ok(result),
-                    Err(_) => Err(io_error("failed to receive snapshot")),
-                }
-            },
-            Err(_) => Err(io_error("failed to send snapshot command")),
-        }
+        self.control_tx.send(msg)
+            .map_err(|_| SnapshotError::ReceiverShutdown)
+            .and_then(move |_| rx.recv().map_err(|_| SnapshotError::InternalError))
+    }
+
+    /// Retrieves a snapshot of the current metric state asynchronously.
+    pub fn get_snapshot_async(&self) -> Result<oneshot::Receiver<Snapshot>, SnapshotError> {
+        let (tx, rx) = oneshot::channel();
+        let msg = ControlFrame::SnapshotAsync(tx);
+
+        self.control_tx.send(msg)
+            .map_err(|_| SnapshotError::ReceiverShutdown)
+            .map(move |_| rx)
     }
 }

--- a/src/data/counter.rs
+++ b/src/data/counter.rs
@@ -18,7 +18,9 @@ impl<T: Clone + Eq + Hash> Counter<T> {
         *value += delta;
     }
 
-    pub fn values(&self) -> Vec<(T, i64)> { self.data.iter().map(|(k, v)| (k.clone(), *v)).collect() }
+    pub fn values(&self) -> Vec<(T, i64)> {
+        self.data.iter().map(|(k, v)| (k.clone(), *v)).collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/data/gauge.rs
+++ b/src/data/gauge.rs
@@ -18,7 +18,9 @@ impl<T: Clone + Eq + Hash> Gauge<T> {
         *ivalue = value;
     }
 
-    pub fn values(&self) -> Vec<(T, u64)> { self.data.iter().map(|(k, v)| (k.clone(), *v)).collect() }
+    pub fn values(&self) -> Vec<(T, u64)> {
+        self.data.iter().map(|(k, v)| (k.clone(), *v)).collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/data/histogram.rs
+++ b/src/data/histogram.rs
@@ -79,7 +79,9 @@ impl WindowedHistogram {
         }
     }
 
-    pub fn update(&mut self, value: u64) { self.buckets[self.bucket_index].saturating_record(value); }
+    pub fn update(&mut self, value: u64) {
+        self.buckets[self.bucket_index].saturating_record(value);
+    }
 
     pub fn merged(&self) -> HdrHistogram<u64> {
         let mut base = HdrHistogram::new_from(&self.buckets[self.bucket_index]);

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,18 +1,14 @@
-use fnv::FnvBuildHasher;
-use hashbrown::HashMap;
-use hdrhistogram::Histogram as HdrHistogram;
-use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::{
     fmt::{self, Display},
     hash::Hash,
-    marker::PhantomData,
 };
 
 pub mod counter;
 pub mod gauge;
 pub mod histogram;
+pub mod snapshot;
 
-pub(crate) use self::{counter::Counter, gauge::Gauge, histogram::Histogram};
+pub(crate) use self::{counter::Counter, gauge::Gauge, histogram::Histogram, snapshot::Snapshot};
 
 /// A measurement.
 ///
@@ -55,9 +51,13 @@ pub(crate) enum Sample<T> {
 pub(crate) struct ScopedKey<T: Clone + Eq + Hash + Display>(u64, T);
 
 impl<T: Clone + Eq + Hash + Display> ScopedKey<T> {
-    pub(crate) fn id(&self) -> u64 { self.0 }
+    pub(crate) fn id(&self) -> u64 {
+        self.0
+    }
 
-    pub(crate) fn into_string_scoped(self, scope: String) -> StringScopedKey<T> { StringScopedKey(scope, self.1) }
+    pub(crate) fn into_string_scoped(self, scope: String) -> StringScopedKey<T> {
+        StringScopedKey(scope, self.1)
+    }
 }
 
 /// A string scoped metric key.
@@ -81,7 +81,7 @@ impl<T: Clone + Eq + Hash + Display> Sample<T> {
             Sample::Gauge(key, value) => Sample::Gauge(ScopedKey(scope_id, key), value),
             Sample::TimingHistogram(key, start, end, count) => {
                 Sample::TimingHistogram(ScopedKey(scope_id, key), start, end, count)
-            },
+            }
             Sample::ValueHistogram(key, count) => Sample::ValueHistogram(ScopedKey(scope_id, key), count),
         }
     }
@@ -91,8 +91,27 @@ impl<T: Clone + Eq + Hash + Display> Sample<T> {
 ///
 /// This represents a floating-point value from 0 to 100, with a string label to be used for
 /// displaying the given percentile.
-#[derive(Clone)]
-pub(crate) struct Percentile(pub String, pub f64);
+#[derive(Derivative, Debug, Clone)]
+#[derivative(Hash, PartialEq)]
+pub struct Percentile {
+    label: String,
+
+    #[derivative(Hash = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    value: f64,
+}
+
+impl Percentile {
+    pub fn label(&self) -> &str {
+        self.label.as_str()
+    }
+
+    pub fn percentile(&self) -> f64 {
+        self.value
+    }
+}
+
+impl Eq for Percentile {}
 
 impl From<f64> for Percentile {
     fn from(p: f64) -> Self {
@@ -107,245 +126,9 @@ impl From<f64> for Percentile {
             _ => {
                 let raw = format!("p{}", clamped);
                 raw.replace(".", "")
-            },
+            }
         };
 
-        Percentile(label, clamped)
-    }
-}
-
-/// A point-in-time view of metric data.
-#[derive(Default)]
-pub struct Snapshot {
-    signed_data: HashMap<String, i64, FnvBuildHasher>,
-    unsigned_data: HashMap<String, u64, FnvBuildHasher>,
-}
-
-impl Snapshot {
-    /// Gets the counter value for the given metric key.
-    ///
-    /// Returns `None` if the metric key has no counter value in this snapshot.
-    pub fn count(&self, key: &str) -> Option<&i64> { self.signed_data.get(key) }
-
-    /// Gets the gauge value for the given metric key.
-    ///
-    /// Returns `None` if the metric key has no gauge value in this snapshot.
-    pub fn gauge(&self, key: &str) -> Option<&u64> { self.unsigned_data.get(key) }
-
-    /// Gets the given timing percentile for given metric key.
-    ///
-    /// Returns `None` if the metric key has no value at the given percentile in this snapshot.
-    pub fn timing_histogram(&self, key: &str, percentile: f64) -> Option<&u64> {
-        let p = Percentile::from(percentile);
-        let fkey = format!("{}_ns_{}", key, p.0);
-        self.unsigned_data.get(&fkey)
-    }
-
-    /// Gets the given value percentile for the given metric key.
-    ///
-    /// Returns `None` if the metric key has no value at the given percentile in this snapshot.
-    pub fn value_histogram(&self, key: &str, percentile: f64) -> Option<&u64> {
-        let p = Percentile::from(percentile);
-        let fkey = format!("{}_{}", key, p.0);
-        self.unsigned_data.get(&fkey)
-    }
-
-    /// Gets a collection of the metrics with signed values.
-    pub fn get_signed_data(&self) -> Vec<(String, i64)> {
-        self.signed_data.iter().map(|(a, b)| (a.clone(), *b)).collect()
-    }
-
-    /// Gets a collection of the metrics with unsigned values.
-    pub fn get_unsigned_data(&self) -> Vec<(String, u64)> {
-        self.unsigned_data.iter().map(|(a, b)| (a.clone(), *b)).collect()
-    }
-}
-
-impl Serialize for Snapshot {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let field_count = self.signed_data.len() + self.unsigned_data.len();
-        let mut map = serializer.serialize_map(Some(field_count))?;
-        for (k, v) in &self.signed_data {
-            map.serialize_entry(k, v)?;
-        }
-        for (k, v) in &self.unsigned_data {
-            map.serialize_entry(k, v)?;
-        }
-        map.end()
-    }
-}
-
-/// Builder for creating a snapshot.
-pub(crate) struct SnapshotBuilder<T> {
-    inner: Snapshot,
-    _marker: PhantomData<T>,
-}
-
-#[allow(dead_code)]
-impl<T: Send + Eq + Hash + Send + Display + Clone> SnapshotBuilder<T> {
-    /// Creates an empty `SnapshotBuilder`.
-    pub(crate) fn new() -> SnapshotBuilder<T> {
-        SnapshotBuilder {
-            inner: Default::default(),
-            _marker: PhantomData,
-        }
-    }
-
-    /// Stores a counter value for the given metric key.
-    pub(crate) fn set_count(&mut self, key: T, value: i64) {
-        let fkey = format!("{}", key);
-        self.inner.signed_data.insert(fkey, value);
-    }
-
-    /// Stores a gauge value for the given metric key.
-    pub(crate) fn set_gauge(&mut self, key: T, value: u64) {
-        let fkey = format!("{}", key);
-        self.inner.unsigned_data.insert(fkey, value);
-    }
-
-    /// Sets timing percentiles for the given metric key.
-    ///
-    /// From the given `HdrHistogram`, all the specific `percentiles` will be extracted and stored.
-    pub(crate) fn set_timing_histogram(&mut self, key: T, h: HdrHistogram<u64>, percentiles: &[Percentile]) {
-        for percentile in percentiles {
-            let fkey = format!("{}_ns_{}", key, percentile.0);
-            let value = h.value_at_percentile(percentile.1);
-            self.inner.unsigned_data.insert(fkey, value);
-        }
-    }
-
-    /// Sets value percentiles for the given metric key.
-    ///
-    /// From the given `HdrHistogram`, all the specific `percentiles` will be extracted and stored.
-    pub(crate) fn set_value_histogram(&mut self, key: T, h: HdrHistogram<u64>, percentiles: &[Percentile]) {
-        for percentile in percentiles {
-            let fkey = format!("{}_{}", key, percentile.0);
-            let value = h.value_at_percentile(percentile.1);
-            self.inner.unsigned_data.insert(fkey, value);
-        }
-    }
-
-    /// Converts this `SnapshotBuilder` into a `Snapshot`.
-    pub(crate) fn into_inner(self) -> Snapshot { self.inner }
-}
-
-#[derive(Debug)]
-pub enum SnapshotError {
-    /// There was an internal error when trying to collect a snapshot.
-    InternalError,
-
-    /// A snapshot was requested but the receiver is shutdown.
-    ReceiverShutdown,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Percentile, SnapshotBuilder};
-    use hdrhistogram::Histogram;
-
-    #[test]
-    fn test_snapshot_simple_set_and_get() {
-        let key = "ok".to_owned();
-        let mut sb = SnapshotBuilder::new();
-        sb.set_count(key.clone(), 1);
-        sb.set_gauge(key.clone(), 42);
-
-        let snapshot = sb.into_inner();
-        assert_eq!(snapshot.count(&key).unwrap(), &1);
-        assert_eq!(snapshot.gauge(&key).unwrap(), &42);
-    }
-
-    #[test]
-    fn test_snapshot_percentiles() {
-        {
-            let mut sb = SnapshotBuilder::new();
-            let mut h1 = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-            h1.saturating_record(500_000);
-            h1.saturating_record(750_000);
-            h1.saturating_record(1_000_000);
-            h1.saturating_record(1_250_000);
-
-            let tkey = "ok".to_owned();
-            let mut tpercentiles = Vec::new();
-            tpercentiles.push(Percentile::from(0.0));
-            tpercentiles.push(Percentile::from(50.0));
-            tpercentiles.push(Percentile::from(99.0));
-            tpercentiles.push(Percentile::from(100.0));
-
-            sb.set_timing_histogram(tkey.clone(), h1, &tpercentiles);
-
-            let snapshot = sb.into_inner();
-            let min_tpercentile = snapshot.timing_histogram(&tkey, tpercentiles[0].1);
-            let p50_tpercentile = snapshot.timing_histogram(&tkey, tpercentiles[1].1);
-            let p99_tpercentile = snapshot.timing_histogram(&tkey, tpercentiles[2].1);
-            let max_tpercentile = snapshot.timing_histogram(&tkey, tpercentiles[3].1);
-            let fake_tpercentile = snapshot.timing_histogram(&tkey, 63.0);
-
-            assert!(min_tpercentile.is_some());
-            assert!(p50_tpercentile.is_some());
-            assert!(p99_tpercentile.is_some());
-            assert!(max_tpercentile.is_some());
-            assert!(fake_tpercentile.is_none());
-        }
-
-        {
-            let mut sb = SnapshotBuilder::new();
-            let mut h2 = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
-            h2.saturating_record(500_000);
-            h2.saturating_record(750_000);
-            h2.saturating_record(1_000_000);
-            h2.saturating_record(1_250_000);
-
-            let vkey = "ok".to_owned();
-            let mut vpercentiles = Vec::new();
-            vpercentiles.push(Percentile::from(0.0));
-            vpercentiles.push(Percentile::from(50.0));
-            vpercentiles.push(Percentile::from(99.0));
-            vpercentiles.push(Percentile::from(100.0));
-
-            sb.set_value_histogram(vkey.clone(), h2, &vpercentiles);
-
-            let snapshot = sb.into_inner();
-            let min_vpercentile = snapshot.value_histogram(&vkey, vpercentiles[0].1);
-            let p50_vpercentile = snapshot.value_histogram(&vkey, vpercentiles[1].1);
-            let p99_vpercentile = snapshot.value_histogram(&vkey, vpercentiles[2].1);
-            let max_vpercentile = snapshot.value_histogram(&vkey, vpercentiles[3].1);
-            let fake_vpercentile = snapshot.value_histogram(&vkey, 63.0);
-
-            assert!(min_vpercentile.is_some());
-            assert!(p50_vpercentile.is_some());
-            assert!(p99_vpercentile.is_some());
-            assert!(max_vpercentile.is_some());
-            assert!(fake_vpercentile.is_none());
-        }
-    }
-
-    #[test]
-    fn test_percentiles() {
-        let min_p = Percentile::from(0.0);
-        assert_eq!(min_p.0, "min");
-
-        let max_p = Percentile::from(100.0);
-        assert_eq!(max_p.0, "max");
-
-        let clamped_min_p = Percentile::from(-20.0);
-        assert_eq!(clamped_min_p.0, "min");
-        assert_eq!(clamped_min_p.1, 0.0);
-
-        let clamped_max_p = Percentile::from(1442.0);
-        assert_eq!(clamped_max_p.0, "max");
-        assert_eq!(clamped_max_p.1, 100.0);
-
-        let p99_p = Percentile::from(99.0);
-        assert_eq!(p99_p.0, "p99");
-
-        let p999_p = Percentile::from(99.9);
-        assert_eq!(p999_p.0, "p999");
-
-        let p9999_p = Percentile::from(99.99);
-        assert_eq!(p9999_p.0, "p9999");
+        Percentile { label, value: clamped }
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -232,6 +232,15 @@ impl<T: Send + Eq + Hash + Send + Display + Clone> SnapshotBuilder<T> {
     pub(crate) fn into_inner(self) -> Snapshot { self.inner }
 }
 
+#[derive(Debug)]
+pub enum SnapshotError {
+    /// There was an internal error when trying to collect a snapshot.
+    InternalError,
+
+    /// A snapshot was requested but the receiver is shutdown.
+    ReceiverShutdown,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Percentile, SnapshotBuilder};

--- a/src/data/snapshot.rs
+++ b/src/data/snapshot.rs
@@ -1,0 +1,295 @@
+use super::Percentile;
+use hdrhistogram::Histogram as HdrHistogram;
+use std::collections::HashMap;
+use std::fmt::Display;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TypedMeasurement {
+    Counter(String, i64),
+    Gauge(String, u64),
+    TimingHistogram(String, SummarizedHistogram),
+    ValueHistogram(String, SummarizedHistogram),
+}
+
+/// A point-in-time view of metric data.
+#[derive(Default)]
+pub struct Snapshot {
+    measurements: Vec<TypedMeasurement>,
+}
+
+impl Snapshot {
+    /// Stores a counter value for the given metric key.
+    pub(crate) fn set_count<T>(&mut self, key: T, value: i64)
+    where
+        T: Display,
+    {
+        self.measurements
+            .push(TypedMeasurement::Counter(key.to_string(), value));
+    }
+
+    /// Stores a gauge value for the given metric key.
+    pub(crate) fn set_gauge<T>(&mut self, key: T, value: u64)
+    where
+        T: Display,
+    {
+        self.measurements.push(TypedMeasurement::Gauge(key.to_string(), value));
+    }
+
+    /// Sets timing percentiles for the given metric key.
+    ///
+    /// From the given `HdrHistogram`, all the specific `percentiles` will be extracted and stored.
+    pub(crate) fn set_timing_histogram<T>(&mut self, key: T, h: HdrHistogram<u64>, percentiles: &[Percentile])
+    where
+        T: Display,
+    {
+        let summarized = SummarizedHistogram::from_histogram(h, percentiles);
+        self.measurements
+            .push(TypedMeasurement::TimingHistogram(key.to_string(), summarized));
+    }
+
+    /// Sets value percentiles for the given metric key.
+    ///
+    /// From the given `HdrHistogram`, all the specific `percentiles` will be extracted and stored.
+    pub(crate) fn set_value_histogram<T>(&mut self, key: T, h: HdrHistogram<u64>, percentiles: &[Percentile])
+    where
+        T: Display,
+    {
+        let summarized = SummarizedHistogram::from_histogram(h, percentiles);
+        self.measurements
+            .push(TypedMeasurement::ValueHistogram(key.to_string(), summarized));
+    }
+
+    /// Converts this [`Snapshot`] into `[`SimpleSnapshot`].
+    ///
+    /// [`SimpleSnapshot`] provides a programmatic interface to more easily sift through the
+    /// metrics within, without needing to evaluate all of them.
+    pub fn into_simple(self) -> SimpleSnapshot {
+        SimpleSnapshot::from_snapshot(self)
+    }
+
+    /// Converts this [`Snapshot`] to the underlying vector of measurements.
+    pub fn into_vec(self) -> Vec<TypedMeasurement> {
+        self.measurements
+    }
+}
+
+/// A user-friendly metric snapshot that allows easy retrieval of values.
+///
+/// This is good for programmatic exploration of values, whereas [`Snapshot`] is designed around
+/// being consumed by output adapters that send metrics to external collection systems.
+#[derive(Default)]
+pub struct SimpleSnapshot {
+    pub(crate) counters: HashMap<String, i64>,
+    pub(crate) gauges: HashMap<String, u64>,
+    pub(crate) timings: HashMap<String, SummarizedHistogram>,
+    pub(crate) values: HashMap<String, SummarizedHistogram>,
+}
+
+impl SimpleSnapshot {
+    pub(crate) fn from_snapshot(s: Snapshot) -> Self {
+        let mut ss = SimpleSnapshot::default();
+        for metric in s.into_vec() {
+            match metric {
+                TypedMeasurement::Counter(key, value) => {
+                    ss.counters.insert(key, value);
+                }
+                TypedMeasurement::Gauge(key, value) => {
+                    ss.gauges.insert(key, value);
+                }
+                TypedMeasurement::TimingHistogram(key, value) => {
+                    ss.timings.insert(key, value);
+                }
+                TypedMeasurement::ValueHistogram(key, value) => {
+                    ss.values.insert(key, value);
+                }
+            }
+        }
+        ss
+    }
+
+    /// Gets the counter value for the given metric key.
+    ///
+    /// Returns `None` if the metric key has no counter value in this snapshot.
+    pub fn count(&self, key: &str) -> Option<i64> {
+        self.counters.get(key).cloned()
+    }
+
+    /// Gets the gauge value for the given metric key.
+    ///
+    /// Returns `None` if the metric key has no gauge value in this snapshot.
+    pub fn gauge(&self, key: &str) -> Option<u64> {
+        self.gauges.get(key).cloned()
+    }
+
+    /// Gets the given timing percentile for given metric key.
+    ///
+    /// Returns `None` if the metric key has no value at the given percentile in this snapshot.
+    pub fn timing_histogram(&self, key: &str, percentile: f64) -> Option<u64> {
+        let p = Percentile::from(percentile);
+        self.timings.get(key).and_then(|s| s.measurements().get(&p)).cloned()
+    }
+
+    /// Gets the given value percentile for the given metric key.
+    ///
+    /// Returns `None` if the metric key has no value at the given percentile in this snapshot.
+    pub fn value_histogram(&self, key: &str, percentile: f64) -> Option<u64> {
+        let p = Percentile::from(percentile);
+        self.values.get(key).and_then(|s| s.measurements().get(&p)).cloned()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SummarizedHistogram {
+    count: u64,
+    measurements: HashMap<Percentile, u64>,
+}
+
+impl SummarizedHistogram {
+    pub fn from_histogram(histogram: HdrHistogram<u64>, percentiles: &[Percentile]) -> Self {
+        let mut measurements = HashMap::default();
+        let count = histogram.len();
+
+        for percentile in percentiles {
+            let value = histogram.value_at_percentile(percentile.value);
+            measurements.insert(percentile.clone(), value);
+        }
+
+        SummarizedHistogram { count, measurements }
+    }
+
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    pub fn measurements(&self) -> &HashMap<Percentile, u64> {
+        &self.measurements
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Percentile, Snapshot, TypedMeasurement};
+    use hdrhistogram::Histogram;
+
+    #[test]
+    fn test_snapshot_simple_set_and_get() {
+        let key = "ok".to_owned();
+        let mut snapshot = Snapshot::default();
+        snapshot.set_count(key.clone(), 1);
+        snapshot.set_gauge(key.clone(), 42);
+
+        let values = snapshot.into_vec();
+
+        assert_eq!(values[0], TypedMeasurement::Counter("ok".to_owned(), 1));
+        assert_eq!(values[1], TypedMeasurement::Gauge("ok".to_owned(), 42));
+    }
+
+    #[test]
+    fn test_snapshot_percentiles() {
+        {
+            let mut snapshot = Snapshot::default();
+            let mut h1 = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+            h1.saturating_record(500_000);
+            h1.saturating_record(750_000);
+            h1.saturating_record(1_000_000);
+            h1.saturating_record(1_250_000);
+
+            let tkey = "ok".to_owned();
+            let mut tpercentiles = Vec::new();
+            tpercentiles.push(Percentile::from(0.0));
+            tpercentiles.push(Percentile::from(50.0));
+            tpercentiles.push(Percentile::from(99.0));
+            tpercentiles.push(Percentile::from(100.0));
+            let fake = Percentile::from(63.0);
+
+            snapshot.set_timing_histogram(tkey.clone(), h1, &tpercentiles);
+
+            let values = snapshot.into_vec();
+            match values.get(0) {
+                Some(TypedMeasurement::TimingHistogram(key, summary)) => {
+                    assert_eq!(key, "ok");
+                    assert_eq!(summary.count(), 4);
+
+                    let min_tpercentile = summary.measurements().get(&tpercentiles[0]);
+                    let p50_tpercentile = summary.measurements().get(&tpercentiles[1]);
+                    let p99_tpercentile = summary.measurements().get(&tpercentiles[2]);
+                    let max_tpercentile = summary.measurements().get(&tpercentiles[3]);
+                    let fake_tpercentile = summary.measurements().get(&fake);
+
+                    assert!(min_tpercentile.is_some());
+                    assert!(p50_tpercentile.is_some());
+                    assert!(p99_tpercentile.is_some());
+                    assert!(max_tpercentile.is_some());
+                    assert!(fake_tpercentile.is_none());
+                }
+                _ => panic!("expected timing histogram value! actual: {:?}", values[0]),
+            }
+        }
+
+        {
+            let mut snapshot = Snapshot::default();
+            let mut h1 = Histogram::<u64>::new_with_bounds(1, u64::max_value(), 3).unwrap();
+            h1.saturating_record(500_000);
+            h1.saturating_record(750_000);
+            h1.saturating_record(1_000_000);
+            h1.saturating_record(1_250_000);
+
+            let tkey = "ok".to_owned();
+            let mut tpercentiles = Vec::new();
+            tpercentiles.push(Percentile::from(0.0));
+            tpercentiles.push(Percentile::from(50.0));
+            tpercentiles.push(Percentile::from(99.0));
+            tpercentiles.push(Percentile::from(100.0));
+            let fake = Percentile::from(63.0);
+
+            snapshot.set_value_histogram(tkey.clone(), h1, &tpercentiles);
+
+            let values = snapshot.into_vec();
+            match values.get(0) {
+                Some(TypedMeasurement::ValueHistogram(key, summary)) => {
+                    assert_eq!(key, "ok");
+                    assert_eq!(summary.count(), 4);
+
+                    let min_tpercentile = summary.measurements().get(&tpercentiles[0]);
+                    let p50_tpercentile = summary.measurements().get(&tpercentiles[1]);
+                    let p99_tpercentile = summary.measurements().get(&tpercentiles[2]);
+                    let max_tpercentile = summary.measurements().get(&tpercentiles[3]);
+                    let fake_tpercentile = summary.measurements().get(&fake);
+
+                    assert!(min_tpercentile.is_some());
+                    assert!(p50_tpercentile.is_some());
+                    assert!(p99_tpercentile.is_some());
+                    assert!(max_tpercentile.is_some());
+                    assert!(fake_tpercentile.is_none());
+                }
+                _ => panic!("expected value histogram value! actual: {:?}", values[0]),
+            }
+        }
+    }
+
+    #[test]
+    fn test_percentiles() {
+        let min_p = Percentile::from(0.0);
+        assert_eq!(min_p.label(), "min");
+
+        let max_p = Percentile::from(100.0);
+        assert_eq!(max_p.label(), "max");
+
+        let clamped_min_p = Percentile::from(-20.0);
+        assert_eq!(clamped_min_p.label(), "min");
+        assert_eq!(clamped_min_p.percentile(), 0.0);
+
+        let clamped_max_p = Percentile::from(1442.0);
+        assert_eq!(clamped_max_p.label(), "max");
+        assert_eq!(clamped_max_p.percentile(), 100.0);
+
+        let p99_p = Percentile::from(99.0);
+        assert_eq!(p99_p.label(), "p99");
+
+        let p999_p = Percentile::from(99.9);
+        assert_eq!(p999_p.label(), "p999");
+
+        let p9999_p = Percentile::from(99.99);
+        assert_eq!(p9999_p.label(), "p9999");
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -4,10 +4,14 @@ use std::{
 };
 
 /// Helpers to create an I/O error from a string.
-pub fn io_error(reason: &str) -> Error { Error::new(ErrorKind::Other, reason) }
+pub fn io_error(reason: &str) -> Error {
+    Error::new(ErrorKind::Other, reason)
+}
 
 /// Converts a duration to nanoseconds.
-pub fn duration_as_nanos(d: Duration) -> u64 { (d.as_secs() * 1_000_000_000) + u64::from(d.subsec_nanos()) }
+pub fn duration_as_nanos(d: Duration) -> u64 {
+    (d.as_secs() * 1_000_000_000) + u64::from(d.subsec_nanos())
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 //! comes to sinks. [`Receiver`] also allows configuring the capacity of the underlying channels to
 //! finely tune resource consumption.
 //!
-//! Being based on [`crossbeam-channel`] allows us to process close to five million metrics per second
-//! on a single core, with very low ingest latencies: 325-350ns on average at full throughput.
+//! Being based on [`crossbeam-channel`] allows us to process close to fifteen million metrics per
+//! second on a single core, with very low ingest latencies: 100ns on average at full throughput.
 //!
 //! # Metrics
 //!
@@ -132,6 +132,9 @@
 //! let scoped_sink_three = scoped_sink.scoped(&["super", "secret", "ultra", "special"]);
 //! scoped_sink_two.update_count("widgets", 42);
 //! ```
+#[macro_use]
+extern crate derivative;
+
 mod configuration;
 mod control;
 mod data;
@@ -143,7 +146,7 @@ mod sink;
 pub use self::{
     configuration::Configuration,
     control::Controller,
-    data::Snapshot,
+    data::snapshot::{SimpleSnapshot, Snapshot},
     receiver::Receiver,
     sink::{Sink, SinkError},
 };

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -183,6 +183,10 @@ impl<T: Clone + Eq + Hash + Display + Send> Receiver<T> {
                 let snapshot = self.get_snapshot();
                 let _ = tx.send(snapshot);
             },
+            ControlFrame::SnapshotAsync(tx) => {
+                let snapshot = self.get_snapshot();
+                let _ = tx.send(snapshot);
+            },
         }
     }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -34,7 +34,10 @@ pub struct Sink<T: Clone + Eq + Hash + Display> {
 
 impl<T: Clone + Eq + Hash + Display> Sink<T> {
     pub(crate) fn new(
-        msg_tx: Sender<MessageFrame<ScopedKey<T>>>, clock: Clock, scopes: Arc<Scopes>, scope: String,
+        msg_tx: Sender<MessageFrame<ScopedKey<T>>>,
+        clock: Clock,
+        scopes: Arc<Scopes>,
+        scope: String,
     ) -> Sink<T> {
         let scope_id = scopes.register(scope.clone());
 
@@ -48,7 +51,11 @@ impl<T: Clone + Eq + Hash + Display> Sink<T> {
     }
 
     pub(crate) fn new_with_scope_id(
-        msg_tx: Sender<MessageFrame<ScopedKey<T>>>, clock: Clock, scopes: Arc<Scopes>, scope: String, scope_id: u64,
+        msg_tx: Sender<MessageFrame<ScopedKey<T>>>,
+        clock: Clock,
+        scopes: Arc<Scopes>,
+        scope: String,
+        scope_id: u64,
     ) -> Sink<T> {
         Sink {
             msg_tx,
@@ -86,18 +93,26 @@ impl<T: Clone + Eq + Hash + Display> Sink<T> {
     }
 
     /// Reference to the internal high-speed clock interface.
-    pub fn clock(&self) -> &Clock { &self.clock }
+    pub fn clock(&self) -> &Clock {
+        &self.clock
+    }
 
     /// Updates the count for a given metric.
-    pub fn update_count(&self, key: T, delta: i64) { self.send(Sample::Count(key, delta)) }
+    pub fn update_count(&self, key: T, delta: i64) {
+        self.send(Sample::Count(key, delta))
+    }
 
     /// Updates the value for a given metric.
     ///
     /// This can be used either for setting a gauge or updating a value histogram.
-    pub fn update_gauge(&self, key: T, value: u64) { self.send(Sample::Gauge(key, value)) }
+    pub fn update_gauge(&self, key: T, value: u64) {
+        self.send(Sample::Gauge(key, value))
+    }
 
     /// Updates the timing histogram for a given metric.
-    pub fn update_timing(&self, key: T, start: u64, end: u64) { self.send(Sample::TimingHistogram(key, start, end, 1)) }
+    pub fn update_timing(&self, key: T, start: u64, end: u64) {
+        self.send(Sample::TimingHistogram(key, start, end, 1))
+    }
 
     /// Updates the timing histogram for a given metric, with a count.
     pub fn update_timing_with_count(&self, key: T, start: u64, end: u64, count: u64) {
@@ -105,13 +120,19 @@ impl<T: Clone + Eq + Hash + Display> Sink<T> {
     }
 
     /// Updates the value histogram for a given metric.
-    pub fn update_value(&self, key: T, value: u64) { self.send(Sample::ValueHistogram(key, value)) }
+    pub fn update_value(&self, key: T, value: u64) {
+        self.send(Sample::ValueHistogram(key, value))
+    }
 
     /// Increments the given metric by one.
-    pub fn increment(&self, key: T) { self.update_count(key, 1) }
+    pub fn increment(&self, key: T) {
+        self.update_count(key, 1)
+    }
 
     /// Decrements the given metric by one.
-    pub fn decrement(&self, key: T) { self.update_count(key, -1) }
+    pub fn decrement(&self, key: T) {
+        self.update_count(key, -1)
+    }
 
     /// Sends a raw metric sample to the receiver.
     fn send(&self, sample: Sample<T>) {


### PR DESCRIPTION
In this PR, we've revamped snapshots a bit for a few reasons:
- having the builder was extraneous
- snapshots favored programmatic exploration, not consumption by exporter crates
- no good option for async callers

We still have `Snapshot`, but now we also have `SimpleSnapshot`. `Snapshot` is for exporters, where all the values contained are typed based on an enum variant, and can be iterated over easily since exporters are bulk uploading metrics rather than trying to find a given histogram or counter, etc.  `SimpleSnapshot` provides the previous functionality, exposing only accessors for looking up specific metrics.  A `Snapshot` can be converted to a `SimpleSnapshot`.

`SnapshotBuilder` is gone entirely and rolled directly into `Snapshot`, since we can control method visbility at the crate level.

Almost as important, `Controller` now has a new method -- `get_snapshot_async` -- to get snapshots asynchronously.  We use `tokio-sync::oneshot` to provide a futures-capable receiver to the caller: snapshots are fairly quick to take, but can hit pockets of latency that would otherwise not be great to introduce into executors themselves.